### PR TITLE
Default to latest file when picking from multiple available patches

### DIFF
--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -150,7 +150,8 @@ module.exports = function(grunt) {
 						{	type: 'list',
 							name: 'patch_name',
 							message: 'Please select a patch to apply',
-							choices: possible_patches
+							// Reverse the list so that the default choice is the latest patch
+							choices: possible_patches.reverse()
 						}
 					], function ( answers ) {
 						grunt.log.debug( 'answers:' + JSON.stringify(answers) )

--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -150,8 +150,9 @@ module.exports = function(grunt) {
 						{	type: 'list',
 							name: 'patch_name',
 							message: 'Please select a patch to apply',
-							// Reverse the list so that the default choice is the latest patch
-							choices: possible_patches.reverse()
+							choices: possible_patches,
+							// preselect the most recent patch
+							default: possible_patches.length - 1
 						}
 					], function ( answers ) {
 						grunt.log.debug( 'answers:' + JSON.stringify(answers) )


### PR DESCRIPTION
This makes it so that hitting "enter" when choosing between multiple patches will select the latest patch, not the oldest. Verify with a ticket with multiple patches, e.g. 29546:

![image](https://cloud.githubusercontent.com/assets/442115/4784655/995cf854-5d60-11e4-9572-c9b4ca06f87d.png)

(per suggestion by @markjaquith)