### PR TITLE
Include missing root directory files in wp_dash_exceptions

### DIFF
--- a/lib/patch.js
+++ b/lib/patch.js
@@ -49,6 +49,14 @@ module.exports = {
 	move_to_src : function( diff ){
 		var src = false
 			, wp_dash_exceptions = [
+				'.editorconfig' ,
+				'.gitignore' ,
+				'.jshintrc' ,
+				'.travis.yml' ,
+				'Gruntfile.js' ,
+				'package.json' ,
+				'phpunit.xml.dist' ,
+				'wp-cli.yml' ,
 				'wp-config-sample.php' ,
 				'wp-tests-config-sample.php'
 			]


### PR DESCRIPTION
Example: Patching `package.json` via `grunt patch:31337` fails with the following error:

```
Result:
can't find file to patch at input line 5
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|Index: package.json
|===================================================================
|--- package.json	(revision 31464)
|+++ package.json	(working copy)
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
1 out of 1 hunk ignored
```