### PR TITLE
Pass diff as diff-cmd for svn

### DIFF
--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -301,7 +301,7 @@ module.exports = function(grunt) {
 		}
 
 		var uploadPatchWithCredentials = function( username, password ) {
-			var diffCommand = is_svn() ? 'svn diff' : 'git diff'
+			var diffCommand = is_svn() ? 'svn diff --diff-cmd diff' : 'git diff'
 
 			exec( diffCommand, function(error, result, code) {
 				var client = xmlrpc.createSecureClient({


### PR DESCRIPTION
If colordiff is set as the default diff-cmd, the diff uploaded isn't usable.

Fixes #38