### PR TITLE
Use Clortho to securely save credentials for patch uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
     "grunt": ">=0.4.0"
   },
   "dependencies": {
-    "request": "~2.69.0",
+    "clortho": "^1.2.2",
     "inquirer": "~0.12.0",
+    "request": "~2.69.0",
     "underscore": "~1.8.3",
     "underscore.string": "~3.3.4",
     "xmlrpc": "^1.3.1"

--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -19,6 +19,7 @@ var request = require( 'request' )
 	, patch = require( '../lib/patch.js' )
 	, regex = require( '../lib/regex.js' )
 	, xmlrpc = require('xmlrpc')
+	, clortho = require( 'clortho' )
 
 _.str = _.str = require('underscore.string')
 _.mixin( _.str.exports() )
@@ -333,12 +334,19 @@ module.exports = function(grunt) {
 			})
 		}
 		inquirer.prompt(
-			[
-				{ type: 'input', name: 'username', message: 'Enter your WordPress.org username' },
-				{ type: 'password', name: 'password', message: 'Enter your WordPress.org password' }
-			],
-			function(answers) {
-				uploadPatchWithCredentials( answers.username, answers.password )
+			[{
+				type: 'input',
+				name: 'username',
+				message: 'Enter your WordPress.org username'
+			}],
+			function( answers ) {
+				clortho({
+					service: 'WordPress.org Trac',
+					username: answers.username,
+					message: 'Enter your WordPress.org password:'
+			}).then( function( credential ) {
+					uploadPatchWithCredentials( credential.username, credential.password )
+				});
 			}
 		)
 	})


### PR DESCRIPTION
When a patch is uploaded, the user is prompted for the username and password each time before uploading to a ticket. This will save the credentials in the system store and only prompt for the username for each upload.

Alternatively, we could store the username in a config file and not prompt for it each time, but asking for it each time probably isn't that horrible.

See #37.
