### PR TITLE
Use custom user agent for requests

### DIFF
--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -140,12 +140,12 @@ module.exports = function( grunt ) {
 		let possiblePatches;
 
 		grunt.log.debug( 'getPatchFromTicket: ' + patchUrl );
-		
+
 		const requestOptions = {
 			url: patchUrl,
 			headers: {
-				'User-Agent': 'grunt-patch-wordpress'
-			}
+				'User-Agent': 'grunt-patch-wordpress',
+			},
 		};
 		request( requestOptions, ( error, response, body ) => {
 			if ( ! error && 200 === response.statusCode ) {
@@ -199,12 +199,12 @@ module.exports = function( grunt ) {
 
 	function getPatch( patchUrl ) {
 		grunt.log.debug( 'getting patch: ' + patchUrl );
-		
+
 		const requestOptions = {
 			url: patchUrl,
 			headers: {
-				'User-Agent': 'grunt-patch-wordpress'
-			}
+				'User-Agent': 'grunt-patch-wordpress',
+			},
 		};
 		request( requestOptions, ( error, response, body ) => {
 			if ( ! error && 200 === response.statusCode ) {

--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -1,6 +1,6 @@
 /*
  * grunt-patch-wordpress
- * https://github.com/aaronjorbin/grunt-patch-wordpress
+ * https://github.com/WordPress/grunt-patch-wordpress
  * Based on https://gist.github.com/markjaquith/4219135
  *
  *
@@ -144,7 +144,7 @@ module.exports = function( grunt ) {
 		const requestOptions = {
 			url: patchUrl,
 			headers: {
-				'User-Agent': 'grunt-patch-wordpress',
+				'User-Agent': 'grunt-patch-wordpress; https://github.com/WordPress/grunt-patch-wordpress',
 			},
 		};
 		request( requestOptions, ( error, response, body ) => {
@@ -203,7 +203,7 @@ module.exports = function( grunt ) {
 		const requestOptions = {
 			url: patchUrl,
 			headers: {
-				'User-Agent': 'grunt-patch-wordpress',
+				'User-Agent': 'grunt-patch-wordpress; https://github.com/WordPress/grunt-patch-wordpress',
 			},
 		};
 		request( requestOptions, ( error, response, body ) => {

--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -140,7 +140,14 @@ module.exports = function( grunt ) {
 		let possiblePatches;
 
 		grunt.log.debug( 'getPatchFromTicket: ' + patchUrl );
-		request( patchUrl, ( error, response, body ) => {
+		
+		const requestOptions = {
+			url: patchUrl,
+			headers: {
+				'User-Agent': 'grunt-patch-wordpress'
+			}
+		};
+		request( requestOptions, ( error, response, body ) => {
 			if ( ! error && 200 === response.statusCode ) {
 				matches = regex.patchAttachments( body );
 				grunt.log.debug( 'matches: ' + JSON.stringify( matches ) );
@@ -192,7 +199,14 @@ module.exports = function( grunt ) {
 
 	function getPatch( patchUrl ) {
 		grunt.log.debug( 'getting patch: ' + patchUrl );
-		request( patchUrl, ( error, response, body ) => {
+		
+		const requestOptions = {
+			url: patchUrl,
+			headers: {
+				'User-Agent': 'grunt-patch-wordpress'
+			}
+		};
+		request( requestOptions, ( error, response, body ) => {
 			if ( ! error && 200 === response.statusCode ) {
 				const level = patch.isAb( body ) ? 1 : 0;
 				const moveToSrc = patch.moveToSrc( body );


### PR DESCRIPTION
Related to https://wordpress.slack.com/archives/C02QB8GMM/p1593710560323900

On WordPress Trac UA rate-limiting is enabled. A custom UA would allow to whitelist requests by this task. 