### PR TITLE
Update wp-scripts and ensure that tests pass using the new rulesets.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,11 +2,11 @@ module.exports = {
 	root: true,
 	env: {
 		es6: true,
-		node: true
+		node: true,
 	},
 	extends: 'plugin:@wordpress/eslint-plugin/recommended',
 	rules: {
 		'one-var': [ 'error', 'never' ],
-		'prefer-arrow-callback': [ 'error' ]
-	}
+		'prefer-arrow-callback': [ 'error' ],
+	},
 };

--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -1,0 +1,35 @@
+{
+	"extends": "@wordpress/npm-package-json-lint-config",
+	"rules": {
+		"valid-values-license": [ "error", [ "MIT" ] ],
+		"description-format": [
+			"error",
+			{
+				"requireCapitalFirstLetter": true,
+				"requireEndingPeriod": true
+			}
+		],
+		"prefer-no-devDependencies": "error",
+		"require-publishConfig": "error",
+		"require-repository-directory": "error",
+		"valid-values-author": [ "error", [ "The WordPress Contributors" ] ],
+		"valid-values-publishConfig": [
+			"error",
+			[
+				{
+					"access": "public"
+				}
+			]
+		]
+	},
+	"overrides": [
+		{
+			"patterns": [ "./package.json" ],
+			"rules": {
+				"require-publishConfig": "off",
+				"require-repository-directory": "off",
+				"prefer-no-devDependencies": "off"
+			}
+		}
+	]
+}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+// Import the default config file and expose it in the project root.
+// Useful for editor integrations.
+module.exports = require('@wordpress/prettier-config');

--- a/lib/map_old_to_new_file_path.js
+++ b/lib/map_old_to_new_file_path.js
@@ -19,10 +19,16 @@ function mapOldToNewFilePath( filePath, fileMappings ) {
 		}
 
 		// Regex to match the second filename of the diff header.
-		const headerRegex = new RegExp( '((diff \\-\\-git .* )(' + oldPath + ')(\\n))', 'ig' );
+		const headerRegex = new RegExp(
+			'((diff \\-\\-git .* )(' + oldPath + ')(\\n))',
+			'ig'
+		);
 
 		// Regex to match the old and new file name of the chunks within the diff.
-		const chunkFilenameRegex = new RegExp( '((-{3}|\\+{3})( ' + oldPath + '))', 'ig' );
+		const chunkFilenameRegex = new RegExp(
+			'((-{3}|\\+{3})( ' + oldPath + '))',
+			'ig'
+		);
 
 		if ( ! body.match( chunkFilenameRegex ) ) {
 			continue;
@@ -35,7 +41,13 @@ function mapOldToNewFilePath( filePath, fileMappings ) {
 
 		// Logs the mapping.
 		if ( body !== newBody ) {
-			grunt.log.writeln( 'Old file path ' + oldPath + ' found in patch. This path has been automatically replaced by ' + newPath + '.' );
+			grunt.log.writeln(
+				'Old file path ' +
+					oldPath +
+					' found in patch. This path has been automatically replaced by ' +
+					newPath +
+					'.'
+			);
 		}
 	}
 

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -52,7 +52,8 @@ module.exports = {
 		try {
 			diff.split( '\n' ).forEach( ( line ) => {
 				// these are often the first line
-				if ( startsWith( line, 'Index: src/' ) ||
+				if (
+					startsWith( line, 'Index: src/' ) ||
 					startsWith( line, 'Index: tests/' ) ||
 					startsWith( line, 'Index: tools/' ) ||
 					startsWith( line, 'diff --git src' ) ||
@@ -61,13 +62,13 @@ module.exports = {
 					startsWith( line, 'diff --git a/src' ) ||
 					startsWith( line, 'diff --git a/test' ) ||
 					startsWith( line, 'diff --git a/tools' )
-
 				) {
 					throw false;
 				}
 
 				wpDashExceptions.forEach( ( exception ) => {
-					if ( startsWith( line, 'Index: ' + exception ) ||
+					if (
+						startsWith( line, 'Index: ' + exception ) ||
 						startsWith( line, 'diff --git ' + exception ) ||
 						startsWith( line, 'diff --git a/' + exception )
 					) {
@@ -76,7 +77,8 @@ module.exports = {
 				} );
 
 				noWpDashExceptions.forEach( ( exception ) => {
-					if ( startsWith( line, 'Index: ' + exception ) ||
+					if (
+						startsWith( line, 'Index: ' + exception ) ||
 						startsWith( line, 'diff --git ' + exception ) ||
 						startsWith( line, 'diff --git a/' + exception )
 					) {
@@ -84,7 +86,8 @@ module.exports = {
 					}
 				} );
 
-				if ( startsWith( line, 'Index: wp-' ) ||
+				if (
+					startsWith( line, 'Index: wp-' ) ||
 					startsWith( line, 'Index: trunk/wp-' ) ||
 					startsWith( line, 'diff --git wp-' ) ||
 					startsWith( line, 'diff --git a/wp-' )
@@ -98,5 +101,4 @@ module.exports = {
 		}
 		return src;
 	},
-
 };

--- a/lib/regex.js
+++ b/lib/regex.js
@@ -1,6 +1,8 @@
 module.exports = {
 	patchAttachments( html ) {
-		return html.match( /<dt>\s*<a\s+href="([^"]+?)(diff|patch)"\s+title="View attachment">([^<]+)/g );
+		return html.match(
+			/<dt>\s*<a\s+href="([^"]+?)(diff|patch)"\s+title="View attachment">([^<]+)/g
+		);
 	},
 
 	urlsFromAttachmentList( html ) {
@@ -15,12 +17,14 @@ module.exports = {
 		return longMatches
 			.map( ( match ) => {
 				if ( match.match( /(patch|diff)"/ ) ) {
-					return match
-						// Remove any HTML tags.
-						.replace( /<\/?[^>]+>/g, '' )
-						// Collapse consecutive whitespace characters into one space.
-						.replace( /\s+/g, ' ' )
-						.trim();
+					return (
+						match
+							// Remove any HTML tags.
+							.replace( /<\/?[^>]+>/g, '' )
+							// Collapse consecutive whitespace characters into one space.
+							.replace( /\s+/g, ' ' )
+							.trim()
+					);
 				}
 				return false;
 			} )
@@ -30,5 +34,4 @@ module.exports = {
 	localFileClean( file ) {
 		return file.replace( '?', '' ).replace( /\s/g, '' );
 	},
-
 };

--- a/lib/trac.js
+++ b/lib/trac.js
@@ -4,9 +4,11 @@ const grunt = require( 'grunt' );
 module.exports = {
 	convertToRaw( parsedUrl ) {
 		grunt.log.debug( 'convertToRaw: ' + JSON.stringify( parsedUrl ) );
-		parsedUrl.pathname = parsedUrl.pathname.replace( /attachment/, 'raw-attachment' );
+		parsedUrl.pathname = parsedUrl.pathname.replace(
+			/attachment/,
+			'raw-attachment'
+		);
 		grunt.log.debug( 'converted_from_raw: ' + url.format( parsedUrl ) );
 		return url.format( parsedUrl );
 	},
-
 };

--- a/package.json
+++ b/package.json
@@ -1,12 +1,8 @@
 {
 	"name": "grunt-patch-wordpress",
 	"version": "2.0.0",
-	"description": "Patch your core WordPress",
-	"author": {
-		"name": "Aaron Jorbin",
-		"email": "aaron@jorb.in",
-		"url": "http://aaron.jorb.in"
-	},
+	"description": "Patch your core WordPress.",
+	"author": "The WordPress Contributors",
 	"license": "MIT",
 	"keywords": [
 		"gruntplugin"

--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -21,7 +21,7 @@ const regex = require( '../lib/regex.js' );
 const xmlrpc = require( 'xmlrpc' );
 const mapOldToNewFilePath = require( '../lib/map_old_to_new_file_path.js' );
 
-module.exports = function ( grunt ) {
+module.exports = function( grunt ) {
 	let tempFile = 'wppatch.diff';
 	const defaults = {
 		tracUrl: 'core.trac.wordpress.org',
@@ -354,7 +354,7 @@ module.exports = function ( grunt ) {
 	grunt.registerTask(
 		'patch_wordpress',
 		'Patch your develop-wordpress directory like a boss',
-		function ( ticket, afterProtocal ) {
+		function( ticket, afterProtocal ) {
 			const done = this.async();
 			const options = this.options( defaults );
 
@@ -371,9 +371,9 @@ module.exports = function ( grunt ) {
 				// look for diffs and patches in the root of the checkout and
 				// prompt using inquirer to pick one
 
-				const fileFinderCommand = isSvn()
-					? 'svn status '
-					: 'git ls-files --other --exclude-standard';
+				const fileFinderCommand = isSvn() ?
+					'svn status ' :
+					'git ls-files --other --exclude-standard';
 
 				exec( fileFinderCommand, ( error, result, code ) => {
 					localFile( error, result, code, done, options );
@@ -387,7 +387,7 @@ module.exports = function ( grunt ) {
 	grunt.registerTask(
 		'upload_patch',
 		'Upload the current diff of your develop-wordpress directory to Trac',
-		function ( ticketNumber ) {
+		function( ticketNumber ) {
 			const done = this.async();
 			const options = this.options( defaults );
 
@@ -401,10 +401,10 @@ module.exports = function ( grunt ) {
 				);
 			}
 
-			const uploadPatchWithCredentials = function ( username, password ) {
-				const diffCommand = isSvn()
-					? 'svn diff --diff-cmd diff'
-					: 'git diff HEAD';
+			const uploadPatchWithCredentials = function( username, password ) {
+				const diffCommand = isSvn() ?
+					'svn diff --diff-cmd diff' :
+					'git diff HEAD';
 
 				if ( ! isSvn() ) {
 					execSync( 'git add .' );

--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -21,7 +21,7 @@ const regex = require( '../lib/regex.js' );
 const xmlrpc = require( 'xmlrpc' );
 const mapOldToNewFilePath = require( '../lib/map_old_to_new_file_path.js' );
 
-module.exports = function( grunt ) {
+module.exports = function ( grunt ) {
 	let tempFile = 'wppatch.diff';
 	const defaults = {
 		tracUrl: 'core.trac.wordpress.org',
@@ -58,8 +58,12 @@ module.exports = function( grunt ) {
 			patchArgs.push( '-p' + level );
 			patchArgs.push( '--input=' + tempFile );
 
-			grunt.log.debug( 'patch options: ' + JSON.stringify( patchOptions ) );
-			grunt.log.debug( 'patch arguments: ' + JSON.stringify( patchArgs ) );
+			grunt.log.debug(
+				'patch options: ' + JSON.stringify( patchOptions )
+			);
+			grunt.log.debug(
+				'patch arguments: ' + JSON.stringify( patchArgs )
+			);
 			grunt.log.debug( 'patch tempFile: ' + JSON.stringify( tempFile ) );
 
 			// Maps old file paths in patches to new file paths.
@@ -97,40 +101,66 @@ module.exports = function( grunt ) {
 		// if patchUrl is a github url
 		if ( 'github.com' === parsedUrl.hostname ) {
 			grunt.log.debug( 'github url detected: ' + patchUrl );
-			if ( '.diff' !== patchUrl.slice( -5 ) && '.patch' !== patchUrl.slice( -6 ) ) {
+			if (
+				'.diff' !== patchUrl.slice( -5 ) &&
+				'.patch' !== patchUrl.slice( -6 )
+			) {
 				patchUrl += '.diff';
 			}
 			getPatch( patchUrl, options );
 
-		// if patchUrl is a full url and is a raw-attachement, just apply it
-		} else if ( parsedUrl.hostname === options.tracUrl && parsedUrl.pathname.match( /raw-attachment/ ) ) {
+			// if patchUrl is a full url and is a raw-attachement, just apply it
+		} else if (
+			parsedUrl.hostname === options.tracUrl &&
+			parsedUrl.pathname.match( /raw-attachment/ )
+		) {
 			getPatch( patchUrl, options );
 
-		// if patchUrl is full url and is an attachment, convert it to a raw attachment
-		} else if ( parsedUrl.hostname === options.tracUrl && parsedUrl.pathname.match( /attachment/ ) && parsedUrl.pathname.match( /(patch|diff)/ ) ) {
+			// if patchUrl is full url and is an attachment, convert it to a raw attachment
+		} else if (
+			parsedUrl.hostname === options.tracUrl &&
+			parsedUrl.pathname.match( /attachment/ ) &&
+			parsedUrl.pathname.match( /(patch|diff)/ )
+		) {
 			getPatch( trac.convertToRaw( parsedUrl, options ) );
 
-		// if patchUrl is just a ticket number, get a list of patches on that ticket and allow user to choose one
-		} else if ( parsedUrl.hostname === options.tracUrl && parsedUrl.pathname.match( /ticket/ ) ) {
+			// if patchUrl is just a ticket number, get a list of patches on that ticket and allow user to choose one
+		} else if (
+			parsedUrl.hostname === options.tracUrl &&
+			parsedUrl.pathname.match( /ticket/ )
+		) {
 			getPatchFromTicket( patchUrl, options );
 
-		// if we just enter a number, assume it is a ticket number
-		} else if ( null === parsedUrl.hostname && ! parsedUrl.pathname.match( /\./ ) ) {
+			// if we just enter a number, assume it is a ticket number
+		} else if (
+			null === parsedUrl.hostname &&
+			! parsedUrl.pathname.match( /\./ )
+		) {
 			getPatchFromTicketNumber( patchUrl, options );
 
-		// if patchUrl is a local file, just use that
+			// if patchUrl is a local file, just use that
 		} else if ( null === parsedUrl.hostname ) {
 			getLocalPatch( patchUrl, options );
 
-		// We've failed in our mission
+			// We've failed in our mission
 		} else {
-			grunt.event.emit( 'fileFile', 'All matching failed.  Please enter a ticket url, ticket number, patch url' );
+			grunt.event.emit(
+				'fileFile',
+				'All matching failed.  Please enter a ticket url, ticket number, patch url'
+			);
 		}
 	}
 
 	function getPatchFromTicketNumber( patchUrl, options ) {
 		grunt.log.debug( 'getPatchFromTicketNumber: ' + patchUrl );
-		getPatchFromTicket( 'https://' + options.tracUrl + '/attachment/ticket/' + patchUrl + '/', options );
+		getPatchFromTicket(
+			'https://' +
+				options.tracUrl +
+				'/attachment/ticket/' +
+				patchUrl +
+				'/',
+			options
+		);
 	}
 
 	function getPatchFromTicket( patchUrl, options ) {
@@ -144,7 +174,8 @@ module.exports = function( grunt ) {
 		const requestOptions = {
 			url: patchUrl,
 			headers: {
-				'User-Agent': 'grunt-patch-wordpress; https://github.com/WordPress/grunt-patch-wordpress',
+				'User-Agent':
+					'grunt-patch-wordpress; https://github.com/WordPress/grunt-patch-wordpress',
 			},
 		};
 		request( requestOptions, ( error, response, body ) => {
@@ -153,35 +184,67 @@ module.exports = function( grunt ) {
 				grunt.log.debug( 'matches: ' + JSON.stringify( matches ) );
 
 				if ( null === matches ) {
-					grunt.event.emit( 'fileFail', patchUrl + '\ncontains no attachments' );
+					grunt.event.emit(
+						'fileFail',
+						patchUrl + '\ncontains no attachments'
+					);
 				} else if ( 1 === matches.length ) {
-					matchUrl = options.tracUrl + regex.urlsFromAttachmentList( matches[ 0 ] )[ 1 ];
-					getPatch( trac.convertToRaw( url.parse( 'https://' + matchUrl ) ), options );
+					matchUrl =
+						options.tracUrl +
+						regex.urlsFromAttachmentList( matches[ 0 ] )[ 1 ];
+					getPatch(
+						trac.convertToRaw( url.parse( 'https://' + matchUrl ) ),
+						options
+					);
 				} else {
 					longMatches = regex.longMatches( body );
 					possiblePatches = regex.possiblePatches( longMatches );
 
-					grunt.log.debug( 'possiblePatches: ' + JSON.stringify( possiblePatches ) );
-					grunt.log.debug( 'longMatches: ' + JSON.stringify( longMatches ) );
-					inquirer.prompt( [
-						{	type: 'list',
-							name: 'patch_name',
-							message: 'Please select a patch to apply',
-							choices: possiblePatches,
+					grunt.log.debug(
+						'possiblePatches: ' + JSON.stringify( possiblePatches )
+					);
+					grunt.log.debug(
+						'longMatches: ' + JSON.stringify( longMatches )
+					);
+					inquirer
+						.prompt( [
+							{
+								type: 'list',
+								name: 'patch_name',
+								message: 'Please select a patch to apply',
+								choices: possiblePatches,
 
-							// preselect the most recent patch
-							default: possiblePatches.length - 1,
-						},
-					] ).then( ( answers ) => {
-						grunt.log.debug( 'answers:' + JSON.stringify( answers ) );
-						matchUrl = options.tracUrl +
-						regex.urlsFromAttachmentList( matches[ possiblePatches.indexOf( answers.patch_name ) ] )[ 1 ];
-						getPatch( trac.convertToRaw( url.parse( 'https://' + matchUrl ) ), options );
-					} );
+								// preselect the most recent patch
+								default: possiblePatches.length - 1,
+							},
+						] )
+						.then( ( answers ) => {
+							grunt.log.debug(
+								'answers:' + JSON.stringify( answers )
+							);
+							matchUrl =
+								options.tracUrl +
+								regex.urlsFromAttachmentList(
+									matches[
+										possiblePatches.indexOf(
+											answers.patch_name
+										)
+									]
+								)[ 1 ];
+							getPatch(
+								trac.convertToRaw(
+									url.parse( 'https://' + matchUrl )
+								),
+								options
+							);
+						} );
 				}
 			} else {
 				// something went wrong
-				grunt.event.emit( 'fileFail', 'getPatchFromTicket fail \n status: ' + response.statusCode );
+				grunt.event.emit(
+					'fileFail',
+					'getPatchFromTicket fail \n status: ' + response.statusCode
+				);
 			}
 		} );
 
@@ -203,7 +266,8 @@ module.exports = function( grunt ) {
 		const requestOptions = {
 			url: patchUrl,
 			headers: {
-				'User-Agent': 'grunt-patch-wordpress; https://github.com/WordPress/grunt-patch-wordpress',
+				'User-Agent':
+					'grunt-patch-wordpress; https://github.com/WordPress/grunt-patch-wordpress',
 			},
 		};
 		request( requestOptions, ( error, response, body ) => {
@@ -215,7 +279,10 @@ module.exports = function( grunt ) {
 				grunt.event.emit( 'fileReady', level, moveToSrc );
 			} else {
 				// something went wrong
-				grunt.event.emit( 'fileFail', 'getPatch_fail \n status: ' + response.statusCode );
+				grunt.event.emit(
+					'fileFail',
+					'getPatch_fail \n status: ' + response.statusCode
+				);
 			}
 		} );
 	}
@@ -226,16 +293,24 @@ module.exports = function( grunt ) {
 		grunt.log.errorlns( '' );
 		grunt.log.errorlns( 'To use this command, please:' );
 		grunt.log.errorlns( '' );
-		grunt.log.errorlns( '1) have a diff or patch in your WordPress Directory' );
+		grunt.log.errorlns(
+			'1) have a diff or patch in your WordPress Directory'
+		);
 		grunt.log.errorlns( '' );
-		grunt.log.errorlns( '2) enter a ticket number, e.g. grunt patch:15705' );
+		grunt.log.errorlns(
+			'2) enter a ticket number, e.g. grunt patch:15705'
+		);
 		grunt.log.errorlns( '' );
-		grunt.log.errorlns( '3) enter a ticket url, e.g. grunt patch:https://core.trac.wordpress.org/ticket/15705' );
+		grunt.log.errorlns(
+			'3) enter a ticket url, e.g. grunt patch:https://core.trac.wordpress.org/ticket/15705'
+		);
 		grunt.log.errorlns( '' );
-		grunt.log.errorlns( '4) enter a patch url, e.g. grunt patch:https://core.trac.wordpress.org/attachment/ticket/11817/13711.diff' );
+		grunt.log.errorlns(
+			'4) enter a patch url, e.g. grunt patch:https://core.trac.wordpress.org/attachment/ticket/11817/13711.diff'
+		);
 		grunt.log.errorlns( '' );
 
-		if ( 'string' === typeof ( msg ) ) {
+		if ( 'string' === typeof msg ) {
 			grunt.verbose.errorlns( 'msg: ' + msg );
 		}
 
@@ -244,9 +319,12 @@ module.exports = function( grunt ) {
 
 	function localFile( error, result, code, done, options ) {
 		if ( ! error ) {
-			const files = result.split( '\n' ).filter( ( file ) => (
-				file.includes( 'patch' ) || file.includes( 'diff' )
-			) );
+			const files = result
+				.split( '\n' )
+				.filter(
+					( file ) =>
+						file.includes( 'patch' ) || file.includes( 'diff' )
+				);
 			grunt.log.debug( 'files: ' + JSON.stringify( files ) );
 
 			if ( 0 === files.length ) {
@@ -254,112 +332,151 @@ module.exports = function( grunt ) {
 			} else if ( 1 === files.length ) {
 				applyPatch( regex.localFileClean( files[ 0 ] ), done, options );
 			} else {
-				inquirer.prompt( [
-					{	type: 'list',
-						name: 'file',
-						message: 'Please select a file to apply',
-						choices: files,
-					},
-				] ).then( ( answers ) => {
-					const file = regex.localFileClean( answers.file );
-					applyPatch( file, done, options );
-				} );
+				inquirer
+					.prompt( [
+						{
+							type: 'list',
+							name: 'file',
+							message: 'Please select a file to apply',
+							choices: files,
+						},
+					] )
+					.then( ( answers ) => {
+						const file = regex.localFileClean( answers.file );
+						applyPatch( file, done, options );
+					} );
 			}
 		} else {
 			fileFail( done, 'local file fail' );
 		}
 	}
 
-	grunt.registerTask( 'patch_wordpress', 'Patch your develop-wordpress directory like a boss', function( ticket, afterProtocal ) {
-		const done = this.async();
-		const options = this.options( defaults );
+	grunt.registerTask(
+		'patch_wordpress',
+		'Patch your develop-wordpress directory like a boss',
+		function ( ticket, afterProtocal ) {
+			const done = this.async();
+			const options = this.options( defaults );
 
-		// since URLs contain a : which is the seperator for grunt, we
-		// need to reassemble the url.
-		if ( 'undefined' !== typeof afterProtocal ) {
-			ticket = ticket + ':' + afterProtocal;
-		}
-
-		grunt.log.debug( 'ticket: ' + ticket );
-		grunt.log.debug( 'options: ' + JSON.stringify( options ) );
-
-		if ( 'undefined' === typeof ticket ) {
-			// look for diffs and patches in the root of the checkout and
-			// prompt using inquirer to pick one
-
-			const fileFinderCommand = isSvn() ? 'svn status ' : 'git ls-files --other --exclude-standard';
-
-			exec( fileFinderCommand, ( error, result, code ) => {
-				localFile( error, result, code, done, options );
-			} );
-		} else {
-			applyPatch( ticket, done, options );
-		}
-	} );
-
-	grunt.registerTask( 'upload_patch', 'Upload the current diff of your develop-wordpress directory to Trac', function( ticketNumber ) {
-		const done = this.async();
-		const options = this.options( defaults );
-
-		grunt.log.debug( 'ticketNumber: ' + ticketNumber );
-		grunt.log.debug( 'options: ' + JSON.stringify( options ) );
-
-		ticketNumber = parseInt( ticketNumber, 10 );
-		if ( 'number' !== typeof ticketNumber ) {
-			grunt.fail.warn( 'A ticket number is required to upload a patch.' );
-		}
-
-		const uploadPatchWithCredentials = function( username, password ) {
-			const diffCommand = isSvn() ? 'svn diff --diff-cmd diff' : 'git diff HEAD';
-
-			if ( ! isSvn() ) {
-				execSync( 'git add .' );
+			// since URLs contain a : which is the seperator for grunt, we
+			// need to reassemble the url.
+			if ( 'undefined' !== typeof afterProtocal ) {
+				ticket = ticket + ':' + afterProtocal;
 			}
 
-			exec( diffCommand, ( error, result ) => {
-				const client = xmlrpc.createSecureClient( {
-					hostname: options.tracUrl,
-					port: 443,
-					path: '/login/xmlrpc',
-					basic_auth: { // eslint-disable-line camelcase
-						user: username,
-						pass: password,
-					},
+			grunt.log.debug( 'ticket: ' + ticket );
+			grunt.log.debug( 'options: ' + JSON.stringify( options ) );
+
+			if ( 'undefined' === typeof ticket ) {
+				// look for diffs and patches in the root of the checkout and
+				// prompt using inquirer to pick one
+
+				const fileFinderCommand = isSvn()
+					? 'svn status '
+					: 'git ls-files --other --exclude-standard';
+
+				exec( fileFinderCommand, ( error, result, code ) => {
+					localFile( error, result, code, done, options );
 				} );
-				client.methodCall(
-					'ticket.putAttachment',
-					[
-						ticketNumber,
-						ticketNumber + '.diff',
-						'', // description. empty for now.
-						new Buffer.from( new Buffer.from( result ).toString( 'base64' ), 'base64' ),
-						false, // never overwrite the old file
-					], ( err ) => {
-						if ( ! isSvn() ) {
-							exec( 'git reset' );
-						}
-
-						if ( null === err ) {
-							grunt.log.writeln( 'Uploaded patch.' );
-							done();
-						} else {
-							grunt.fail.warn( 'Something went wrong when attempting to upload the patch. Please confirm your credentials and the ticket number. ' + err );
-						}
-					}
-				);
-			} );
-		};
-		if ( process.env.WPORG_USERNAME && process.env.WPORG_PASSWORD ) {
-			uploadPatchWithCredentials( process.env.WPORG_USERNAME, process.env.WPORG_PASSWORD );
-		} else {
-			inquirer.prompt(
-				[
-					{ type: 'input', name: 'username', message: 'Enter your WordPress.org username' },
-					{ type: 'password', name: 'password', message: 'Enter your WordPress.org password' },
-				] ).then( ( answers ) => {
-				uploadPatchWithCredentials( answers.username, answers.password );
+			} else {
+				applyPatch( ticket, done, options );
 			}
-			);
 		}
-	} );
+	);
+
+	grunt.registerTask(
+		'upload_patch',
+		'Upload the current diff of your develop-wordpress directory to Trac',
+		function ( ticketNumber ) {
+			const done = this.async();
+			const options = this.options( defaults );
+
+			grunt.log.debug( 'ticketNumber: ' + ticketNumber );
+			grunt.log.debug( 'options: ' + JSON.stringify( options ) );
+
+			ticketNumber = parseInt( ticketNumber, 10 );
+			if ( 'number' !== typeof ticketNumber ) {
+				grunt.fail.warn(
+					'A ticket number is required to upload a patch.'
+				);
+			}
+
+			const uploadPatchWithCredentials = function ( username, password ) {
+				const diffCommand = isSvn()
+					? 'svn diff --diff-cmd diff'
+					: 'git diff HEAD';
+
+				if ( ! isSvn() ) {
+					execSync( 'git add .' );
+				}
+
+				exec( diffCommand, ( error, result ) => {
+					const client = xmlrpc.createSecureClient( {
+						hostname: options.tracUrl,
+						port: 443,
+						path: '/login/xmlrpc',
+						basic_auth: {
+							// eslint-disable-line camelcase
+							user: username,
+							pass: password,
+						},
+					} );
+					client.methodCall(
+						'ticket.putAttachment',
+						[
+							ticketNumber,
+							ticketNumber + '.diff',
+							'', // description. empty for now.
+							new Buffer.from(
+								new Buffer.from( result ).toString( 'base64' ),
+								'base64'
+							),
+							false, // never overwrite the old file
+						],
+						( err ) => {
+							if ( ! isSvn() ) {
+								exec( 'git reset' );
+							}
+
+							if ( null === err ) {
+								grunt.log.writeln( 'Uploaded patch.' );
+								done();
+							} else {
+								grunt.fail.warn(
+									'Something went wrong when attempting to upload the patch. Please confirm your credentials and the ticket number. ' +
+										err
+								);
+							}
+						}
+					);
+				} );
+			};
+			if ( process.env.WPORG_USERNAME && process.env.WPORG_PASSWORD ) {
+				uploadPatchWithCredentials(
+					process.env.WPORG_USERNAME,
+					process.env.WPORG_PASSWORD
+				);
+			} else {
+				inquirer
+					.prompt( [
+						{
+							type: 'input',
+							name: 'username',
+							message: 'Enter your WordPress.org username',
+						},
+						{
+							type: 'password',
+							name: 'password',
+							message: 'Enter your WordPress.org password',
+						},
+					] )
+					.then( ( answers ) => {
+						uploadPatchWithCredentials(
+							answers.username,
+							answers.password
+						);
+					} );
+			}
+		}
+	);
 };

--- a/test/patch_wordpress_test.js
+++ b/test/patch_wordpress_test.js
@@ -14,7 +14,15 @@ describe( 'grunt_patch_wordpress', () => {
 	} );
 
 	it( 'convertToRaw converts urls', () => {
-		expect( trac.convertToRaw( url.parse( 'https://core.trac.wordpress.org/attachment/ticket/26700/26700.diff' ) ) ).toEqual( 'https://core.trac.wordpress.org/raw-attachment/ticket/26700/26700.diff' );
+		expect(
+			trac.convertToRaw(
+				url.parse(
+					'https://core.trac.wordpress.org/attachment/ticket/26700/26700.diff'
+				)
+			)
+		).toEqual(
+			'https://core.trac.wordpress.org/raw-attachment/ticket/26700/26700.diff'
+		);
 	} );
 
 	describe( 'Level Calculator', () => {
@@ -28,19 +36,30 @@ describe( 'grunt_patch_wordpress', () => {
 
 	describe( 'mapOldToNewFilePath', () => {
 		const fileMappings = {
-			'src/wp-admin/js/color-picker.js': 'src/js/_enqueues/lib/color-picker.js',
+			'src/wp-admin/js/color-picker.js':
+				'src/js/_enqueues/lib/color-picker.js',
 			'wp-admin/js/color-picker.js': 'js/_enqueues/lib/color-picker.js',
 		};
 
 		describe( 'old to new', () => {
 			beforeAll( () => {
-				grunt.file.copy( './test/fixtures/patch_wordpress_1.diff', './test/tmp/patch_wordpress_1_copy.diff' );
-				mapOldToNewFilePath( './test/tmp/patch_wordpress_1_copy.diff', fileMappings );
+				grunt.file.copy(
+					'./test/fixtures/patch_wordpress_1.diff',
+					'./test/tmp/patch_wordpress_1_copy.diff'
+				);
+				mapOldToNewFilePath(
+					'./test/tmp/patch_wordpress_1_copy.diff',
+					fileMappings
+				);
 			} );
 
 			it( 'replaces old file paths with new file paths in the diff', () => {
-				const expected = grunt.file.read( './test/expected/patch_wordpress_1.diff' );
-				const actual = grunt.file.read( './test/tmp/patch_wordpress_1_copy.diff' );
+				const expected = grunt.file.read(
+					'./test/expected/patch_wordpress_1.diff'
+				);
+				const actual = grunt.file.read(
+					'./test/tmp/patch_wordpress_1_copy.diff'
+				);
 
 				expect( actual ).toEqual( expected );
 			} );
@@ -52,13 +71,23 @@ describe( 'grunt_patch_wordpress', () => {
 
 		describe( 'new stay unchanged', () => {
 			beforeAll( () => {
-				grunt.file.copy( './test/fixtures/patch_wordpress_2.diff', './test/tmp/patch_wordpress_2_copy.diff' );
-				mapOldToNewFilePath( './test/tmp/patch_wordpress_2_copy.diff', fileMappings );
+				grunt.file.copy(
+					'./test/fixtures/patch_wordpress_2.diff',
+					'./test/tmp/patch_wordpress_2_copy.diff'
+				);
+				mapOldToNewFilePath(
+					'./test/tmp/patch_wordpress_2_copy.diff',
+					fileMappings
+				);
 			} );
 
-			it( 'doesn\'t replace new file paths', () => {
-				const expected = grunt.file.read( './test/expected/patch_wordpress_2.diff' );
-				const actual = grunt.file.read( './test/tmp/patch_wordpress_2_copy.diff' );
+			it( "doesn't replace new file paths", () => {
+				const expected = grunt.file.read(
+					'./test/expected/patch_wordpress_2.diff'
+				);
+				const actual = grunt.file.read(
+					'./test/tmp/patch_wordpress_2_copy.diff'
+				);
 
 				expect( actual ).toEqual( expected );
 			} );
@@ -70,13 +99,23 @@ describe( 'grunt_patch_wordpress', () => {
 
 		describe( 'unknown stay unchanged', () => {
 			beforeAll( () => {
-				grunt.file.copy( './test/fixtures/patch_wordpress_3.diff', './test/tmp/patch_wordpress_3_copy.diff' );
-				mapOldToNewFilePath( './test/tmp/patch_wordpress_3_copy.diff', fileMappings );
+				grunt.file.copy(
+					'./test/fixtures/patch_wordpress_3.diff',
+					'./test/tmp/patch_wordpress_3_copy.diff'
+				);
+				mapOldToNewFilePath(
+					'./test/tmp/patch_wordpress_3_copy.diff',
+					fileMappings
+				);
 			} );
 
-			it( 'doesn\'t replace file paths that are not in the file mappings object', () => {
-				const expected = grunt.file.read( './test/expected/patch_wordpress_3.diff' );
-				const actual = grunt.file.read( './test/tmp/patch_wordpress_3_copy.diff' );
+			it( "doesn't replace file paths that are not in the file mappings object", () => {
+				const expected = grunt.file.read(
+					'./test/expected/patch_wordpress_3.diff'
+				);
+				const actual = grunt.file.read(
+					'./test/tmp/patch_wordpress_3_copy.diff'
+				);
 
 				expect( actual ).toEqual( expected );
 			} );
@@ -88,17 +127,30 @@ describe( 'grunt_patch_wordpress', () => {
 
 		describe( 'new stay unchanged, old to new', () => {
 			beforeAll( () => {
-				grunt.file.copy( './test/fixtures/patch_wordpress_4.diff', './test/tmp/patch_wordpress_4_copy.diff' );
-				mapOldToNewFilePath( './test/tmp/patch_wordpress_4_copy.diff', fileMappings );
+				grunt.file.copy(
+					'./test/fixtures/patch_wordpress_4.diff',
+					'./test/tmp/patch_wordpress_4_copy.diff'
+				);
+				mapOldToNewFilePath(
+					'./test/tmp/patch_wordpress_4_copy.diff',
+					fileMappings
+				);
 			} );
 
-			it( 'replaces old file paths with new file paths but doesn\'t replace file paths that are not ' +
-				'in the file mappings object in a diff file with multiple diffs', () => {
-				const expected = grunt.file.read( './test/expected/patch_wordpress_4.diff' );
-				const actual = grunt.file.read( './test/tmp/patch_wordpress_4_copy.diff' );
+			it(
+				"replaces old file paths with new file paths but doesn't replace file paths that are not " +
+					'in the file mappings object in a diff file with multiple diffs',
+				() => {
+					const expected = grunt.file.read(
+						'./test/expected/patch_wordpress_4.diff'
+					);
+					const actual = grunt.file.read(
+						'./test/tmp/patch_wordpress_4_copy.diff'
+					);
 
-				expect( actual ).toEqual( expected );
-			} );
+					expect( actual ).toEqual( expected );
+				}
+			);
 
 			afterAll( () => {
 				grunt.file.delete( './test/tmp/patch_wordpress_4_copy.diff' );
@@ -107,17 +159,30 @@ describe( 'grunt_patch_wordpress', () => {
 
 		describe( 'new and unknown stay unchanged', () => {
 			beforeAll( () => {
-				grunt.file.copy( './test/fixtures/patch_wordpress_5.diff', './test/tmp/patch_wordpress_5_copy.diff' );
-				mapOldToNewFilePath( './test/tmp/patch_wordpress_5_copy.diff', fileMappings );
+				grunt.file.copy(
+					'./test/fixtures/patch_wordpress_5.diff',
+					'./test/tmp/patch_wordpress_5_copy.diff'
+				);
+				mapOldToNewFilePath(
+					'./test/tmp/patch_wordpress_5_copy.diff',
+					fileMappings
+				);
 			} );
 
-			it( 'doesn\'t replaces new file paths and file paths that are not in the file mappings object in a diff file' +
-				' with multiple diffs', () => {
-				const expected = grunt.file.read( './test/expected/patch_wordpress_5.diff' );
-				const actual = grunt.file.read( './test/tmp/patch_wordpress_5_copy.diff' );
+			it(
+				"doesn't replaces new file paths and file paths that are not in the file mappings object in a diff file" +
+					' with multiple diffs',
+				() => {
+					const expected = grunt.file.read(
+						'./test/expected/patch_wordpress_5.diff'
+					);
+					const actual = grunt.file.read(
+						'./test/tmp/patch_wordpress_5_copy.diff'
+					);
 
-				expect( actual ).toEqual( expected );
-			} );
+					expect( actual ).toEqual( expected );
+				}
+			);
 
 			afterAll( () => {
 				grunt.file.delete( './test/tmp/patch_wordpress_5_copy.diff' );
@@ -126,13 +191,23 @@ describe( 'grunt_patch_wordpress', () => {
 
 		describe( 'new and unknown stay unchanged, old to new', () => {
 			beforeAll( () => {
-				grunt.file.copy( './test/fixtures/patch_wordpress_6.diff', './test/tmp/patch_wordpress_6_copy.diff' );
-				mapOldToNewFilePath( './test/tmp/patch_wordpress_6_copy.diff', fileMappings );
+				grunt.file.copy(
+					'./test/fixtures/patch_wordpress_6.diff',
+					'./test/tmp/patch_wordpress_6_copy.diff'
+				);
+				mapOldToNewFilePath(
+					'./test/tmp/patch_wordpress_6_copy.diff',
+					fileMappings
+				);
 			} );
 
 			it( 'only replaces old file paths in a diff file with multiple diffs', () => {
-				const expected = grunt.file.read( './test/expected/patch_wordpress_6.diff' );
-				const actual = grunt.file.read( './test/tmp/patch_wordpress_6_copy.diff' );
+				const expected = grunt.file.read(
+					'./test/expected/patch_wordpress_6.diff'
+				);
+				const actual = grunt.file.read(
+					'./test/tmp/patch_wordpress_6_copy.diff'
+				);
 
 				expect( actual ).toEqual( expected );
 			} );
@@ -145,13 +220,23 @@ describe( 'grunt_patch_wordpress', () => {
 		// There is no src folder in core.
 		describe( 'non-src old to new', () => {
 			beforeAll( () => {
-				grunt.file.copy( './test/fixtures/patch_wordpress_7.diff', './test/tmp/patch_wordpress_7_copy.diff' );
-				mapOldToNewFilePath( './test/tmp/patch_wordpress_7_copy.diff', fileMappings );
+				grunt.file.copy(
+					'./test/fixtures/patch_wordpress_7.diff',
+					'./test/tmp/patch_wordpress_7_copy.diff'
+				);
+				mapOldToNewFilePath(
+					'./test/tmp/patch_wordpress_7_copy.diff',
+					fileMappings
+				);
 			} );
 
 			it( 'replaces old file paths with new file paths in a diff with non-src file paths', () => {
-				const expected = grunt.file.read( './test/expected/patch_wordpress_7.diff' );
-				const actual = grunt.file.read( './test/tmp/patch_wordpress_7_copy.diff' );
+				const expected = grunt.file.read(
+					'./test/expected/patch_wordpress_7.diff'
+				);
+				const actual = grunt.file.read(
+					'./test/tmp/patch_wordpress_7_copy.diff'
+				);
 
 				expect( actual ).toEqual( expected );
 			} );

--- a/test/patches.js
+++ b/test/patches.js
@@ -6,10 +6,18 @@ const developGit = grunt.file.read( 'test/fixtures/develop.git.diff' );
 const developSvn = grunt.file.read( 'test/fixtures/develop.svn.diff' );
 const coreIndexGit = grunt.file.read( 'test/fixtures/core.git.index.diff' );
 const coreIndexSvn = grunt.file.read( 'test/fixtures/core.svn.index.diff' );
-const developIndexGit = grunt.file.read( 'test/fixtures/develop.git.index.diff' );
-const developIndexSvn = grunt.file.read( 'test/fixtures/develop.svn.index.diff' );
-const developSampleGit = grunt.file.read( 'test/fixtures/develop.git.wp-config-sample.diff' );
-const developSampleSvn = grunt.file.read( 'test/fixtures/develop.svn.wp-config-sample.diff' );
+const developIndexGit = grunt.file.read(
+	'test/fixtures/develop.git.index.diff'
+);
+const developIndexSvn = grunt.file.read(
+	'test/fixtures/develop.svn.index.diff'
+);
+const developSampleGit = grunt.file.read(
+	'test/fixtures/develop.git.wp-config-sample.diff'
+);
+const developSampleSvn = grunt.file.read(
+	'test/fixtures/develop.svn.wp-config-sample.diff'
+);
 const testsSvn = grunt.file.read( 'test/fixtures/tests.develop.svn.diff' );
 const testsGit = grunt.file.read( 'test/fixtures/tests.develop.git.diff' );
 const abyes = grunt.file.read( 'test/fixtures/git.diff.ab.diff' );

--- a/test/regex.js
+++ b/test/regex.js
@@ -26,9 +26,13 @@ describe( 'regular expressions', () => {
 
 	it( 'url from a list of attachments', () => {
 		const matches = regex.patchAttachments( html23994 );
-		const url = 'core.trac.wordpress.org' + regex.urlsFromAttachmentList( matches[ 0 ] )[ 1 ];
+		const url =
+			'core.trac.wordpress.org' +
+			regex.urlsFromAttachmentList( matches[ 0 ] )[ 1 ];
 
-		expect( url ).toBe( 'core.trac.wordpress.org/attachment/ticket/23994/23994.diff' );
+		expect( url ).toBe(
+			'core.trac.wordpress.org/attachment/ticket/23994/23994.diff'
+		);
 	} );
 
 	it( 'no patches on a ticket', () => {


### PR DESCRIPTION
In addition to adding `prettier`, there are a handful of new changes including the tests for package.json.

The codebase has had `npm run lint:fix` over it, and all of the tests are passing locally.