### PR TITLE
Update engines to properly specificy minimum node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"url": "https://github.com/wordpress/grunt-patch-wordpress/issues"
 	},
 	"engines": {
-		"node": ">= 10"
+		"node": ">= 12"
 	},
 	"main": "Gruntfile.js",
 	"jest": {


### PR DESCRIPTION
In #89 & #90 we dropped support for node 10, but updating the engines property to enforce this was missed.