### PR TITLE
Support moar github url styles

### DIFF
--- a/lib/regex.js
+++ b/lib/regex.js
@@ -34,4 +34,14 @@ module.exports = {
 	localFileClean( file ) {
 		return file.replace( '?', '' ).replace( /\s/g, '' );
 	},
+
+	githubConvert( url ) {
+		const matches = url.match(
+			/(?:github\.com|patch-diff.githubusercontent.com\/raw)\/((?:[^\/]+\/){2}pull\/[0-9]*)/
+		);
+		if ( matches ) {
+			return `https://patch-diff.githubusercontent.com/raw/${ matches[ 1 ] }.diff`;
+		}
+		return false;
+	},
 };

--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -99,15 +99,11 @@ module.exports = function ( grunt ) {
 		} );
 
 		// if patchUrl is a github url
-		if ( 'github.com' === parsedUrl.hostname ) {
-			grunt.log.debug( 'github url detected: ' + patchUrl );
-			if (
-				'.diff' !== patchUrl.slice( -5 ) &&
-				'.patch' !== patchUrl.slice( -6 )
-			) {
-				patchUrl += '.diff';
-			}
-			getPatch( patchUrl, options );
+		if ( regex.githubConvert( patchUrl ) ) {
+			const diffUrl = regex.githubConvert( patchUrl );
+			grunt.log.debug( 'github url detected: ' + diffUrl );
+
+			getPatch( diffUrl, options );
 
 			// if patchUrl is a full url and is a raw-attachement, just apply it
 		} else if (

--- a/test/regex.js
+++ b/test/regex.js
@@ -46,4 +46,43 @@ describe( 'regular expressions', () => {
 
 		expect( regex.localFileClean( filename ) ).toEqual( 'one.diff' );
 	} );
+
+	it.each( [
+		[ 'https://github.com/WordPress/wordpress-develop/pull/740/', false ], // trailing slash
+		[ 'https://github.com/WordPress/wordpress-develop/pull/740', false ], // no trailing slash
+		[
+			'https://github.com/WordPress/wordpress-develop/pull/740/checks',
+			false,
+		], // checks
+		[
+			'https://github.com/WordPress/wordpress-develop/pull/740/files',
+			false,
+		], // files
+		[
+			'https://github.com/WordPress/wordpress-develop/pull/740.diff',
+			false,
+		], // already diffed
+		[
+			'https://github.com/WordPress/wordpress-develop/pull/740.patch',
+			false,
+		], // already patched
+		[
+			'https://patch-diff.githubusercontent.com/raw/WordPress/wordpress-develop/pull/740.diff',
+			false,
+		], // already diffed and redirected
+		[
+			'https://patch-diff.githubusercontent.com/raw/WordPress/wordpress-develop/pull/740.patch',
+			false,
+		], // already diffed and redirected with patch
+		[ 'https://git.com/WordPress/wordpress-develop/pull/740/files', true ], // not github url
+	] )( 'github url %s should get normalized', ( url, blank ) => {
+		const expected =
+			'https://patch-diff.githubusercontent.com/raw/WordPress/wordpress-develop/pull/740.diff';
+
+		if ( blank ) {
+			expect( regex.githubConvert( url ) ).toBe( false );
+		} else {
+			expect( regex.githubConvert( url ) ).toEqual( expected );
+		}
+	} );
 } );


### PR DESCRIPTION
Currently, a specific format of github urls is needed for the patch to work, but we can actually support moar. This eliminates the requirement that there be no trailing slash and doesn't work if you paste the `/checks` or `/files` url.

Fixes #96