### PR TITLE
Add missing `directory` in `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   # Configure Dependabot updates for GitHub Actions
   - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10


### PR DESCRIPTION
This is apparently required even for the `github-actions` ecosystem.