### PR TITLE
Configure `.github/` as a project root-level path.

### DIFF
--- a/lib/patch.js
+++ b/lib/patch.js
@@ -56,12 +56,15 @@ module.exports = {
 					startsWith( line, 'Index: src/' ) ||
 					startsWith( line, 'Index: tests/' ) ||
 					startsWith( line, 'Index: tools/' ) ||
+					startsWith( line, 'Index: .github/' ) ||
 					startsWith( line, 'diff --git src' ) ||
 					startsWith( line, 'diff --git test' ) ||
 					startsWith( line, 'diff --git tools' ) ||
+					startsWith( line, 'diff --git .github' ) ||
 					startsWith( line, 'diff --git a/src' ) ||
 					startsWith( line, 'diff --git a/test' ) ||
-					startsWith( line, 'diff --git a/tools' )
+					startsWith( line, 'diff --git a/tools' ) ||
+					startsWith( line, 'diff --git a/.github' )
 				) {
 					throw false;
 				}

--- a/test/fixtures/dot-github.git.diff
+++ b/test/fixtures/dot-github.git.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/phpunit-tests.yml b/.github/workflows/phpunit-tests.yml
+index 1234567..89abcde 100644
+--- a/.github/workflows/phpunit-tests.yml
++++ b/.github/workflows/phpunit-tests.yml
+@@ -10,7 +10,7 @@ jobs:
+   test:
+     runs-on: ubuntu-latest
+     steps:
+-      - uses: actions/checkout@v3
++      - uses: actions/checkout@v4
+       - name: Run tests
+         run: npm test

--- a/test/patches.js
+++ b/test/patches.js
@@ -22,6 +22,7 @@ const testsSvn = grunt.file.read( 'test/fixtures/tests.develop.svn.diff' );
 const testsGit = grunt.file.read( 'test/fixtures/tests.develop.git.diff' );
 const abyes = grunt.file.read( 'test/fixtures/git.diff.ab.diff' );
 const coreTrunkSvn = grunt.file.read( 'test/fixtures/core.svn.trunk.diff' );
+const dotGithubGit = grunt.file.read( 'test/fixtures/dot-github.git.diff' );
 
 describe( 'Patch helpers', () => {
 	it( 'git a/b diffs should not automatticaly trigger moving to src', () => {
@@ -41,6 +42,10 @@ describe( 'Patch helpers', () => {
 	it( 'dev.svn diffs should always be applied in the root of the checkout', () => {
 		expect( patch.moveToSrc( developSvn ) ).not.toBe( true );
 		expect( patch.moveToSrc( developIndexSvn ) ).not.toBe( true );
+	} );
+
+	it( '.github diffs should always be applied in the root of the checkout', () => {
+		expect( patch.moveToSrc( dotGithubGit ) ).not.toBe( true );
 	} );
 
 	it( 'core.git.wordpress.org diffs should always be applied in the svn folder', () => {


### PR DESCRIPTION
This adds `.github/` to the list of root-level paths in `moveToSrc()` so patches modifying files in `.github` apply from the checkout root.

## AI Disclosure
AI Assistance: Yes
Description: Claude Code was used to create this pull request before being manually reviewed.

Fixes #107.